### PR TITLE
fix build script for userAgent

### DIFF
--- a/scripts/all-in-one/UE4/all_in_one_packaging.bat
+++ b/scripts/all-in-one/UE4/all_in_one_packaging.bat
@@ -13,6 +13,8 @@ cd workspace
 git clone https://github.com/wit-ai/voicesdk-unreal
 git clone https://github.com/wit-ai/wit-unreal
 
+node ../../update_WITH_VOICESDK_USERAGENT_flag.js
+
 cd voicesdk-unreal
 rmdir /s /q .git
 rmdir /s /q scripts

--- a/scripts/all-in-one/UE5/all_in_one_packaging.bat
+++ b/scripts/all-in-one/UE5/all_in_one_packaging.bat
@@ -19,6 +19,7 @@ git clone https://github.com/wit-ai/voicesdk-unreal
 
 echo ">> 3. add WITH_VOICESDK macro for 'create preset' feature, this can be removed if 2 repos merged."
 node ../update_WITH_VOICESDK_flag.js
+node ../../update_WITH_VOICESDK_USERAGENT_flag.js
 
 echo ">> 4. Copy code and content from wit to voicesdk"
 powershell -Command "cp ./wit-unreal/Source/* ./voicesdk-unreal/Source/ -recurse -force"

--- a/scripts/all-in-one/update_WITH_VOICESDK_USERAGENT_flag.js
+++ b/scripts/all-in-one/update_WITH_VOICESDK_USERAGENT_flag.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+var fs = require('fs');
+const updateFileAsync = require("../helper");
+
+const FILE_PATH = 'wit-unreal\\Source\\Wit\\Wit.Build.cs';
+const KEY_STRING_START = 'PrivateDefinitions.Add("WITH_VOICESDK_USERAGENT=';
+const KEY_STRING_END = '"';
+const replacement = '1'
+
+updateFileAsync(FILE_PATH, KEY_STRING_START, replacement, KEY_STRING_END);


### PR DESCRIPTION
userAgent issue has been fixed in wit-unreal last week.
This is to change the build scripts so when users are using all-in-one, the userAgent can start with voice-sdk-xxx.x.x. 

This was added previously , but I forgot to push.